### PR TITLE
support self closing tags

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -79,9 +79,9 @@ module.exports =
     if match
       result.element     = match[2]
       result.length      = match[0].length
-      result.opening     = true unless match[1] or match[7]
-      result.closing     = true if     match[1]
-      result.selfClosing = true if     match[7]
+      result.opening     = if match[1] or match[7] then false else true
+      result.closing     = if match[1] then true else false
+      result.selfClosing = if match[7] then true else false
       result
     else
       null

--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -49,18 +49,21 @@ module.exports =
     text.substr i + 3
 
   handleTag: (text, stack) ->
-    if match = text.match(/<(\/)?([a-z][^\s\/>]*)/i)
-      if tag = match[2]
-        if match[1]
-          # closing tag: find matching opening tag (if one exists)
-          while stack.length
-            break if stack.pop() is tag
-        else
-          # opening tag, possibly empty
-          stack.push tag unless @isEmpty(tag)
-      text.substr match[0].length
-    else
-      text.substr 1
+    # check if it's a self closing tag
+    unless match = text.match(/(<.*\/>)/)
+      if match = text.match(/<(\/)?([a-z][^\s\/>]*)/i)
+        if tag = match[2]
+          if match[1]
+            # closing tag: find matching opening tag (if one exists)
+            while stack.length
+              break if stack.pop() is tag
+          else
+            # opening tag, possibly empty
+            stack.push tag unless @isEmpty(tag)
+        text.substr match[0].length
+      else
+        text.substr 1
+    else text.substr match[0].length
 
   isEmpty: (tag) ->
     @emptyTags.indexOf(tag.toLowerCase()) > -1

--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -79,7 +79,7 @@ module.exports =
     if match
       result.element     = match[2]
       result.length      = match[0].length
-      result.opening     = true unless match[1]
+      result.opening     = true unless match[1] or match[7]
       result.closing     = true if     match[1]
       result.selfClosing = true if     match[7]
       result

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -35,7 +35,7 @@ describe "LessThanSlash", ->
   describe "parseTag does its thing", ->
     it "detects an opening tag", ->
       text = "<div>"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
@@ -45,7 +45,7 @@ describe "LessThanSlash", ->
 
     it "detects a closing tag", ->
       text = "</div>"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: false
         closing: true
         selfClosing: false
@@ -55,7 +55,7 @@ describe "LessThanSlash", ->
 
     it "detects a self closing tag", ->
       text = "<br/>"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: false
         closing: false
         selfClosing: true
@@ -69,7 +69,7 @@ describe "LessThanSlash", ->
 
     it "doesn't have a cow when an element has properties", ->
       text = "<div class=\"container\">"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
@@ -79,7 +79,7 @@ describe "LessThanSlash", ->
 
     it "doesn't have a cow when you use the wrong quotes", ->
       text = "<div class='container'>"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
@@ -89,7 +89,7 @@ describe "LessThanSlash", ->
 
     it "doesn't have a cow when you use retarded spacing", ->
       text = "<div  class=\"container\" \n  foo=\"bar\">"
-      expect(LessThanSlash.parseTag text).toBe {
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
@@ -99,22 +99,22 @@ describe "LessThanSlash", ->
 
     it "doesn't have a cow when you use lone properties", ->
       text = "<input type=\"text\" required/>"
-      expect(LessThanSlash.parseTag text).toBe {
-        opening: true
+      expect(LessThanSlash.parseTag text).toEqual {
+        opening: false
         closing: false
-        selfClosing: false
+        selfClosing: true
         element: 'input'
         length: 29
       }
 
     it "doesn't have a cow when properties contain a '>'", ->
-      text = "<p ng-show\"5 > 3\">"
-      expect(LessThanSlash.parseTag text).toBe {
+      text = "<p ng-show=\"3 > 5\">Uh oh!"
+      expect(LessThanSlash.parseTag text).toEqual {
         opening: true
         closing: false
         selfClosing: false
         element: 'p'
-        length: 18
+        length: 19
       }
 
   describe "handleTag does its thing", ->

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -54,6 +54,13 @@ describe "LessThanSlash", ->
       expect(text).toBe ">"
       expect(stack.length).toBe 0
 
+    it "finds a self closing tag and skips it", ->
+      stack = []
+      text = "<br/>"
+      text = LessThanSlash.handleTag text, stack
+      expect(text).toBe ">"
+      expect(stack.length).toBe 0
+
     it "doesn't find a tag and returns text, one char advanced", ->
       stack = []
       text = "<- this guy"

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -19,7 +19,7 @@ describe "LessThanSlash", ->
       expect(LessThanSlash.isEmpty "div").toBe false
 
 
-  describe "handleComment does it's thing", ->
+  describe "handleComment does its thing", ->
     it "skips a comment", ->
       text = "<!-- This is some ipsum --><p>Lorem ipsum...</p>"
       expect(LessThanSlash.handleComment text).toBe "<p>Lorem ipsum...</p>"
@@ -32,33 +32,118 @@ describe "LessThanSlash", ->
       text = "<!-- foobar <!-- For some reason someone did this --> -->"
       expect(LessThanSlash.handleComment text).toBe " -->"
 
-  describe "handleTag does it's thing", ->
-    it "finds a open tag", ->
+  describe "parseTag does its thing", ->
+    it "detects an opening tag", ->
+      text = "<div>"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        length: 5
+      }
+
+    it "detects a closing tag", ->
+      text = "</div>"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: false
+        closing: true
+        selfClosing: false
+        element: 'div'
+        length: 6
+      }
+
+    it "detects a self closing tag", ->
+      text = "<br/>"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: false
+        closing: false
+        selfClosing: true
+        element: 'br'
+        length: 5
+      }
+
+    it "returns null when there is no tag", ->
+      text = "No tag here!"
+      expect(LessThanSlash.parseTag text).toBe null
+
+    it "doesn't have a cow when an element has properties", ->
+      text = "<div class=\"container\">"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        length: 23
+      }
+
+    it "doesn't have a cow when you use the wrong quotes", ->
+      text = "<div class='container'>"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        length: 23
+      }
+
+    it "doesn't have a cow when you use retarded spacing", ->
+      text = "<div  class=\"container\" \n  foo=\"bar\">"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        length: 37
+      }
+
+    it "doesn't have a cow when you use lone properties", ->
+      text = "<input type=\"text\" required/>"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'input'
+        length: 29
+      }
+
+    it "doesn't have a cow when properties contain a '>'", ->
+      text = "<p ng-show\"5 > 3\">"
+      expect(LessThanSlash.parseTag text).toBe {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'p'
+        length: 18
+      }
+
+  describe "handleTag does its thing", ->
+    it "finds an opening tag", ->
       stack = []
       text = "<div>"
       text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ">"
+      expect(text).toBe ""
       expect(stack[0]).toBe "div"
 
-    it "finds a close tag and pops the stack", ->
+    it "finds a closing tag and pops the stack", ->
       stack = ["div"]
       text = "</div>"
       text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ">"
+      expect(text).toBe ""
       expect(stack.length).toBe 0
 
     it "finds a tag that is in emptyTags and skips it", ->
       stack = []
       text = "<input>"
       text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ">"
+      expect(text).toBe ""
       expect(stack.length).toBe 0
 
     it "finds a self closing tag and skips it", ->
       stack = []
       text = "<br/>"
       text = LessThanSlash.handleTag text, stack
-      expect(text).toBe ">"
+      expect(text).toBe ""
       expect(stack.length).toBe 0
 
     it "doesn't find a tag and returns text, one char advanced", ->
@@ -68,7 +153,7 @@ describe "LessThanSlash", ->
       expect(text).toBe "- this guy"
       expect(stack.length).toBe 0
 
-  describe "findTagsIn does it's thing", ->
+  describe "findTagsIn does its thing", ->
     it "finds unmatched tags in markup", ->
       text = "<div><p><i></i><span>"
       stack = LessThanSlash.findTagsIn text


### PR DESCRIPTION
Previously, you would need to define all empty tags in the config, which meant when working with frameworks such as AngularJS or React.js that enable the creation of custom elements, you would have to add every custom element used to the config, or deal with:
```
<div>
  <MyCustomElement/>
  </MyCustomElement>
```
when you would expect:
```
<div>
  <MyCustomElement/>
</div>
```

This fork automatically skips self closed tags.