### PR TITLE
add support for curly brace property values

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -77,7 +77,7 @@ module.exports =
       element: ''
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-]+)(=["'](.*?)["'])?)*\s*(\/)?>/i)
+    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-]+)(=["'{](.*?)["'}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -87,6 +87,16 @@ describe "LessThanSlash", ->
         length: 23
       }
 
+    it "plays nicely with JSX curly brace property values", ->
+      text = "<input type=\"text\"disabled={this.props.isDisabled}/>"
+      expect(LessThanSlash.parseTag text).toEqual {
+        opening: false
+        closing: false
+        selfClosing: true
+        element: 'input'
+        length: 52
+      }
+
     it "doesn't have a cow when you use retarded spacing", ->
       text = "<div  class=\"container\" \n  foo=\"bar\">"
       expect(LessThanSlash.parseTag text).toEqual {


### PR DESCRIPTION
Add support for curly braces denoting property values such as those seen in JSX, eg:
```
<input type="text" disabled={false} />
```