### PR TITLE
Refactor for extensibility and maintainability

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -77,7 +77,7 @@ module.exports =
       element: ''
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-]+)(=["'](.*?)["'])?)*\s*(\/)?>/i)
+    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-]+)(=["'{](.*?)["'}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length

--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -5,8 +5,6 @@
 module.exports =
   emptyTags: []
 
-  insertingTags: false
-
   config:
     emptyTags:
       type: "string"
@@ -19,7 +17,7 @@ module.exports =
     atom.workspace.observeTextEditors (editor) =>
       buffer = editor.getBuffer()
       buffer.onDidChange (event) =>
-        if !@insertingTags and event.newText == "/"
+        if event.newText == "/"
           if event.newRange.start.column > 0
             checkText = buffer.getTextInRange [[event.newRange.start.row, event.newRange.start.column - 1], [event.newRange.end.row, event.newRange.end.column]]
             if checkText == "</"

--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -19,13 +19,23 @@ module.exports =
       buffer.onDidChange (event) =>
         if event.newText == "/"
           if event.newRange.start.column > 0
-            checkText = buffer.getTextInRange [[event.newRange.start.row, event.newRange.start.column - 1], [event.newRange.end.row, event.newRange.end.column]]
-            if checkText == "</"
+            checkText = buffer.getTextInRange [[event.newRange.start.row, event.newRange.start.column - 2], [event.newRange.end.row, event.newRange.end.column]]
+            # Check if we just typed a closing tag </
+            # We need to substr relative to the length of the checkText cause
+            # it could be only 2 chars long if we type </ at the start of a line
+            if checkText.substr(checkText.length - 2, checkText.length) == "</"
               text = buffer.getTextInRange [[0, 0], event.oldRange.end]
               stack = @findTagsIn text
               if stack.length
                 tag = stack.pop()
-                buffer.insert event.newRange.end, "#{tag}>"
+                buffer.insert event.newRange.end, "#{tag.element}>"
+            # Check if we just typed a handlebars closing tag {{/
+            else if checkText == '{{/'
+              text = buffer.getTextInRange [[0, 0], event.oldRange.end]
+              stack = @findTagsIn text
+              if stack.length
+                tag = stack.pop()
+                buffer.insert event.newRange.end, "#{tag.element}"
 
   findTagsIn: (text) ->
     stack = []
@@ -42,15 +52,23 @@ module.exports =
         else
           stack = []
           text = text[9..]
-      else if text[0] is "<"
+      else if text[0] is "<" or text[0...2] is '{{'
         text = @handleTag text, stack
       else
-        index = text.indexOf("<")
+        index = @minIndex(text.indexOf("<"), text.indexOf("{{"))
         if !!~index
           text = text.substr index
         else
           break
     stack
+
+  # Finds the minimum index out of two indexes, taking into account indexes of -1
+  minIndex: (a, b) ->
+    return a if a is b
+    return a if b < 0
+    return b if a < 0
+    return a if a < b
+    return b if b < a
 
   handleComment: (text) ->
     ind = text.indexOf '-->'
@@ -67,15 +85,16 @@ module.exports =
       null
 
   handleTag: (text, stack) ->
-    if tag = @parseTag(text)
+    if tag = @parse(text)
       if tag.opening
         # opening tag, possibly empty
-        stack.push tag.element unless @isEmpty(tag.element)
+        stack.push {element: tag.element, brackets: tag.brackets} unless @isEmpty(tag.element)
       # tag
       else if tag.closing
         # closing tag: find matching opening tag (if one exists)
         while stack.length
-          break if stack.pop() is tag.element
+          currentTag = stack.pop()
+          break if currentTag.element is tag.element and currentTag.brackets is tag.brackets
       else if tag.selfClosing
         # self closing tag: ignore it
       else
@@ -85,12 +104,38 @@ module.exports =
       # no match
       text.substr 1
 
+  parse: (text) ->
+    if text[0] == '<'
+      return @parseTag(text)
+    if text[0...2] == '{{'
+      return @parseHandlebars(text)
+    return null
+
+  parseHandlebars: (text) ->
+    result = {
+      opening: false
+      closing: false
+      element: ''
+      brackets: '{{'
+    }
+    match = text.match(/\{\{([#\/])([^\s\/>]+)(\s+([\w-:]+?))*?\s*?\}\}/i)
+    if match
+      result.element     = match[2]
+      result.length      = match[0].length
+      result.opening     = if match[1] is '#' then true else false
+      result.closing     = if match[1] is '/' then true else false
+      result.selfClosing = false
+      result
+    else
+      null
+
   parseTag: (text) ->
     result = {
       opening: false
       closing: false
       selfClosing: false
       element: ''
+      brackets: '<'
       length: 0
     }
     match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'{](.*?)["'}])?)*\s*(\/)?>/i)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "less-than-slash",
   "main": "./lib/less-than-slash",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Adds automatic closing of HTML tags when less-than, slash (</) is typed.",
   "author": "Matthew R Hanlon <mrhanlon@gmail.com> (https://mrhanlon.com)",
   "bugs": "https://github.com/mrhanlon/less-than-slash/issues",

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -87,6 +87,16 @@ describe "LessThanSlash", ->
         length: 23
       }
 
+    it "plays nicely with JSX curly brace property values", ->
+      text = "<input type=\"text\"disabled={this.props.isDisabled}/>"
+      expect(LessThanSlash.parseTag text).toEqual {
+        opening: false
+        closing: false
+        selfClosing: true
+        element: 'input'
+        length: 52
+      }
+
     it "doesn't have a cow when you use retarded spacing", ->
       text = "<div  class=\"container\" \n  foo=\"bar\">"
       expect(LessThanSlash.parseTag text).toEqual {

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -39,13 +39,13 @@ describe "LessThanSlash", ->
     it "correctly completes around comment", ->
         text = "<div><!--<span>-->"
         stack = LessThanSlash.findTagsIn text
-        expect(stack[0]).toBe "div"
+        expect(stack[0].element).toBe "div"
 
     it "completes within comment", ->
         text = "<div><!--<span>"
         stack = LessThanSlash.findTagsIn text
         expect(stack.length).toBe 1
-        expect(stack[0]).toBe "span"
+        expect(stack[0].element).toBe "span"
 
     describe "handleCDATA does its thing", ->
       it "skips a CDATA", ->
@@ -63,13 +63,13 @@ describe "LessThanSlash", ->
       it "correctly completes around CDATA", ->
           text = "<div><![CDATA[<span>]]>"
           stack = LessThanSlash.findTagsIn text
-          expect(stack[0]).toBe "div"
+          expect(stack[0].element).toBe "div"
 
       it "completes within CDATA", ->
           text = "<div><![CDATA[<span>"
           stack = LessThanSlash.findTagsIn text
           expect(stack.length).toBe 1
-          expect(stack[0]).toBe "span"
+          expect(stack[0].element).toBe "span"
 
   describe "parseTag does its thing", ->
     it "detects an opening tag", ->
@@ -78,7 +78,8 @@ describe "LessThanSlash", ->
         opening: true
         closing: false
         selfClosing: false
-        element: 'div'
+        element: 'div',
+        brackets: '<'
         length: 5
       }
 
@@ -89,6 +90,7 @@ describe "LessThanSlash", ->
         closing: true
         selfClosing: false
         element: 'div'
+        brackets: '<'
         length: 6
       }
 
@@ -99,6 +101,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: true
         element: 'br'
+        brackets: '<'
         length: 5
       }
 
@@ -113,6 +116,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'div'
+        brackets: '<'
         length: 23
       }
 
@@ -123,6 +127,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'div'
+        brackets: '<'
         length: 23
       }
 
@@ -133,6 +138,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: true
         element: 'input'
+        brackets: '<'
         length: 52
       }
 
@@ -143,6 +149,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'elem'
+        brackets: '<'
         length: 44
       }
 
@@ -153,6 +160,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'div'
+        brackets: '<'
         length: 37
       }
 
@@ -163,6 +171,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: true
         element: 'input'
+        brackets: '<'
         length: 29
       }
 
@@ -173,6 +182,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'p'
+        brackets: '<'
         length: 19
       }
 
@@ -183,6 +193,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'a'
+        brackets: '<'
         length: 3
       }
 
@@ -193,6 +204,7 @@ describe "LessThanSlash", ->
         closing: false
         selfClosing: false
         element: 'a'
+        brackets: '<'
         length: 12
       }
 
@@ -202,7 +214,7 @@ describe "LessThanSlash", ->
       text = "<div>"
       text = LessThanSlash.handleTag text, stack
       expect(text).toBe ""
-      expect(stack[0]).toBe "div"
+      expect(stack[0].element).toBe "div"
 
     it "finds a closing tag and pops the stack", ->
       stack = ["div"]
@@ -237,13 +249,57 @@ describe "LessThanSlash", ->
       text = "<div><p><i></i><span>"
       stack = LessThanSlash.findTagsIn text
       expect(stack.length).toBe 3
-      expect(stack[0]).toBe "div"
-      expect(stack[1]).toBe "p"
-      expect(stack[2]).toBe "span"
+      expect(stack[0].element).toBe "div"
+      expect(stack[1].element).toBe "p"
+      expect(stack[2].element).toBe "span"
 
     it "correctly finds nested tags with attributes", ->
       text = "<a href=\"#\"><i class=\"fa fa-home\">"
       stack = LessThanSlash.findTagsIn text
       expect(stack.length).toBe 2
-      expect(stack[0]).toBe "a"
-      expect(stack[1]).toBe "i"
+      expect(stack[0].element).toBe "a"
+      expect(stack[1].element).toBe "i"
+
+  describe "parseHandlebars does its thing", ->
+    it "detects an opening tag", ->
+      text = "{{#if currentUser}}"
+      expect(LessThanSlash.parseHandlebars text).toEqual {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'if',
+        brackets: '{{'
+        length: 19
+      }
+
+    it "detects a closing tag", ->
+      text = "{{/if}}"
+      expect(LessThanSlash.parseHandlebars text).toEqual {
+        opening: false
+        closing: true
+        selfClosing: false
+        element: 'if'
+        brackets: '{{'
+        length: 7
+      }
+
+    it "returns null when there is no tag", ->
+      text = "No tag here!"
+      expect(LessThanSlash.parseHandlebars text).toBe null
+
+  describe "minIndex", ->
+    it "returns the lower number", ->
+      lower = LessThanSlash.minIndex(3, 5)
+      expect(lower).toBe 3
+      lower = LessThanSlash.minIndex(5, 3)
+      expect(lower).toBe 3
+
+    it "discards a negative index", ->
+      lower = LessThanSlash.minIndex(3, -1)
+      expect(lower).toBe 3
+      lower = LessThanSlash.minIndex(-1, 3)
+      expect(lower).toBe 3
+
+    it "passes on double negative indicies", ->
+      lower = LessThanSlash.minIndex(-1, -1)
+      expect(lower).toBe -1


### PR DESCRIPTION
I've rewritten a lot of the package to make it more extensible and maintainable.

Autocompletion is now contained in its own function `onSlash` with no dependency on Atom's buffers or events, this makes it super easy to test behaviour of the whole plugin from jasmine.

Things such as comments and CDATA are now handled as their own type of tag and can be closed by typing `</` just like a regular tag.

`findTagsIn` is now `findUnclosedTags`, It now works recursively instead of through a `while` loop and stores tags as objects so that we can later figure out whether they were originally an xml tag or a comment, for example.

It should also be much easier to add parsing support for more tag variants. The `parseNextTag` function uses the `LessThanSlash.parsers` array to figure out which parser to hand the string to.