### PR TITLE
Autocomplete plus integration

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -2,224 +2,165 @@
 # file: less-than-slash.coffee
 # author: @mrhanlon
 #
+
+{
+  xmlparser,
+  xmlcdataparser,
+  xmlcommentparser,
+  underscoretemplateparser,
+  mustacheparser
+} = require './parsers'
+
 module.exports =
-  emptyTags: []
+
+  parsers: [
+    xmlparser,
+    xmlcdataparser,
+    # FIXME see parsers.coffee
+    # xmlcommentparser,
+    underscoretemplateparser,
+    # mustacheparser
+  ]
 
   config:
+    completionMode:
+      title: "Completion Mode"
+      description: "Choose immediate to have your tags completed immediately (the traditional way). Choose suggest to have them appear in an autocomplete suggestion box."
+      type: "string",
+      default: "Immediate"
+      enum: ["Immediate", "Suggest"]
     emptyTags:
+      title: "Empty tags"
+      description: "Elements that do not need a matching closing tag."
       type: "string"
-      default: "!doctype, br, hr, img, input, link, meta, area, base, col, command, embed, keygen, param, source, track, wbr"
+      default: [
+        "!doctype",
+        "br",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "area",
+        "base",
+        "col",
+        "command",
+        "embed",
+        "keygen",
+        "param",
+        "source",
+        "track",
+        "wbr"
+      ].join(" ")
 
   activate: (state) ->
     # Register config change handler to update the empty tags list
-    atom.config.observe "less-than-slash.emptyTags", (value) =>
-      @emptyTags = (tag.toLowerCase() for tag in value.split(/\s*[\s,|]+\s*/))
+    atom.config.observe "less-than-slash.emptyTags", (value) ->
+      xmlparser.emptyTags = (tag.toLowerCase() for tag in value.split(/\s*[\s,|]+\s*/))
+    atom.config.observe "less-than-slash.completionMode", (value) =>
+      @forceComplete = value.toLowerCase() is "immediate"
 
-    atom.workspace.observeTextEditors (editor) =>
+    @forceCompleter = atom.workspace.observeTextEditors (editor) =>
       buffer = editor.getBuffer()
       buffer.onDidChange (event) =>
-        if event.newText == "/"
-          # Ignore it if its right at the start of a line
-          if event.newRange.start.column > 0
-            getCheckText = ->
-              buffer.getTextInRange([
-                [event.newRange.start.row, 0],
-                event.newRange.end
-              ])
-            getText = ->
-              buffer.getTextInRange [[0, 0], event.oldRange.end]
-            if textToInsert = @onSlash getCheckText, getText
-              buffer.delete [
-                [event.newRange.end.row, event.newRange.end.column - 2],
-                event.newRange.end
-              ]
-              buffer.insert [
-                  event.newRange.end.row, event.newRange.end.column - 2
-                ], textToInsert
+        if event.newText is '' then return
+        if not @forceComplete then return
+        if prefix = @getPrefix(editor, event.newRange.end, @parsers)
+          console.log "prefix is", prefix
+          if completion = @getCompletion(editor, event.newRange.end, prefix)
+            console.log completion
+            buffer.delete [
+              [event.newRange.end.row, event.newRange.end.column - prefix.length]
+              event.newRange.end
+            ]
+            buffer.insert [event.newRange.end.row, event.newRange.end.column - prefix.length], completion
 
-  # Takes functions that provide the data so we can lazily collect them
-  onSlash: (getCheckText, getText) ->
-    checkText = getCheckText()
-    if @stringEndsWith checkText, '</'
-      text = getText()
-      if tag = @getNextCloseableTag text
-        if tag.type == "xml"
-          return "</#{tag.element}>"
-        else
-          return "#{tag.element}"
+    @provider =
+      selector: ".text, .source"
+      inclusionPriority: 1
+      excludeLowerPriority: false
+      getSuggestions: ({editor, bufferPosition, scopeDescriptor, activatedManually}) =>
+        if @forceComplete then return []
+        if prefix = @getPrefix(editor, bufferPosition, @parsers)
+          if completion = @getCompletion editor, bufferPosition, prefix
+            return [{
+              text: completion
+              prefix: unless activatedManually then prefix else undefined
+              type: 'tag'
+            }]
+
+  deactivate: () ->
+    @forceCompleter.dispose()
+
+  getCompletion: (editor, bufferPosition, prefix) ->
+    text = editor.getTextInRange [[0, 0], bufferPosition]
+    console.log text
+    unclosedTags = @reduceTags(@traverse(text, @parsers))
+    console.log unclosedTags
+    if tagDescriptor = unclosedTags.pop()
+      console.log prefix, tagDescriptor, @getParser(tagDescriptor.type, @parsers).trigger, @matchPrefix(prefix, @getParser(tagDescriptor.type, @parsers))
+      # Check that this completion corresponds to the trigger
+      if @matchPrefix(prefix, @getParser(tagDescriptor.type, @parsers))
+        console.log 'the completion is ', @getParser(tagDescriptor.type, @parsers).getPair(tagDescriptor)
+        return @getParser(tagDescriptor.type, @parsers).getPair(tagDescriptor)
     return null
 
-  getNextCloseableTag: (text) ->
-    unclosedTags = @findUnclosedTags text
-    if nextCloseableTag = unclosedTags.pop()
-      return nextCloseableTag
-    return null
+  provide: ->
+    @provider
 
-  # When a tag is opened a record of it is added to the stack, when the
-  # corresponding closing tag is found, its record is removed from the stack.
-  findUnclosedTags: (text) ->
-    unclosedTags = []
-    while text != ''
-      if @preTests.indexOf(text[0]) > -1
-        text = @handleNextTag text, unclosedTags
-      else
-        index = @preTests
-          .map((testChar) -> text.indexOf(testChar))
-          .reduce(@minIndex)
-        if !!~index
-          text = text.substr index
-    return unclosedTags
+  # Pure logic
 
-  handleNextTag: (text, unclosedTags) ->
-    if tag = @parseNextTag text
-      if tag.opening
-        # opening tag, possibly empty
-        unclosedTags.push {element: tag.element, type: tag.type} unless @isEmpty(tag.element)
-      else if tag.closing
-        # closing tag: find matching opening tag (if one exists)
-        _unclosedTags = unclosedTags.slice()
-        foundMatchingTag = false
-        while unclosedTags.length
-          currentTag = unclosedTags.pop()
-          if currentTag.element is tag.element and currentTag.type is tag.type
-            foundMatchingTag = true
+  traverse: (text, parsers) ->
+    tags = []
+    loop
+      if text is ''
+        break
+      newIndex = 1
+      for index, parser of parsers
+        if text.match(parser.test)
+          if tagDescriptor = parser.parse(text)
+            tags.push tagDescriptor
+            newIndex = tagDescriptor.length
             break
-        # If we didn't find a matching tag, we've just eaten through our stack!
-        # We have to revert it
-        if !foundMatchingTag
-          unclosedTags.splice 0, 0, _unclosedTags...
-      else if tag.selfClosing
-        # self closing tag: ignore it
-      else
-        console.error "This should be impossible..."
-      return text.substr tag.length
-    else
-      # no match
-      return text.substr 1
+      text = text.substr newIndex
+    tags
 
-  parseNextTag: (text) ->
-    for parser in @parsers
-      for test in parser.test
-        if @stringStartsWith(text, test)
-          return this[parser.parse](text)
-    null
-
-  # Parsers must specify string match based tests for preliminary matching,
-  # after which they will be passed on to the parsing function which may either
-  # return a tag object or reject by passing null
-  parsers: [
-    {
-      test: ["<!--", "-->"]
-      parse: 'parseXMLComment'
-    }
-    {
-      test: ["<![CDATA[", "]]>"]
-      parse: 'parseXMLCDATA'
-    }
-    {
-      test: ["<%=", "%>"]
-      parse: 'parseNoOp'
-    }
-    {
-      test: ["<"]
-      parse: 'parseXMLTag'
-    }
-  ]
-
-  # Preliminary tests are used by findUnclosedTags for skipping over large
-  # potions of text. This should include each unique character lying at the
-  # beginning of a parser test. Failing to include the preTest for a parser
-  # will cause less-than-slash to ignore certain tags and produce unexpected
-  # outputs
-  # This could be computed by using
-  # @parsers
-  #   .map((parser) -> parser.test)
-  #   .reduce((a, b) -> a.concat(b))
-  #   .reduce((test) -> test[0])
-  #   .reduce((preTests, a) ->
-  #     if preTests.indexOf(a) === -1 then preTests.concat([a]) else preTests
-  #    , [])
-  # Perhaps we could compute this at init time, but I'm, just hard coding it for now
-  preTests: ["<", "]", "-"]
-
-  parseNoOp: (text) ->
-    null
-
-  parseXMLTag: (text) ->
-    result = {
-      opening: false
-      closing: false
-      selfClosing: false
-      element: ''
-      type: 'xml'
-      length: 0
-    }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
-    if match
-      result.element     = match[2]
-      result.length      = match[0].length
-      result.opening     = if match[1] or match[7] then false else true
-      result.closing     = if match[1] then true else false
-      result.selfClosing = if match[7] then true else false
-      result
-    else
-      null
-
-  parseXMLComment: (text) ->
-    result = {
-      opening: false
-      closing: false
-      selfClosing: false
-      element: '-->'
-      type: 'xml-comment'
-      length: 0
-    }
-    match = text.match(/(<!--)|(-->)/)
-    if match
-      result.length  = match[0].length
-      result.opening = if match[1] then true else false
-      result.closing = if match[2] then true else false
-      result
-    else
-      null
-
-  parseXMLCDATA: (text) ->
-    result = {
-      opening: false
-      closing: false
-      selfClosing: false
-      element: ']]>'
-      type: 'xml-cdata'
-      length: 0
-    }
-    match = text.match(/(<!\[CDATA\[)|(\]\]>)/i)
-    if match
-      result.length  = match[0].length
-      result.opening = if match[1] then true else false
-      result.closing = if match[2] then true else false
-      result
-    else
-      null
-
-  isEmpty: (tag) ->
-    if tag
-      @emptyTags.indexOf(tag.toLowerCase()) > -1
-    else
-      false
+  reduceTags: (tags) ->
+    result = []
+    loop
+      tag = tags.shift()
+      if not tag then break
+      switch
+        when tag.opening
+          result.push tag
+        when tag.closing
+          _result = result.slice()
+          foundMatchingTag = false
+          while result.length
+            previous = result.pop()
+            if previous.element is tag.element and previous.type is tag.type
+              foundMatchingTag = true
+              break
+          unless foundMatchingTag
+            result = _result
+        when tag.selfClosing
+        else
+          throw new Error("Invalid parse")
+    result
 
   # Utils
+  getPrefix: (editor, bufferPosition, parsers) ->
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    for index, parser of parsers
+      if match = @matchPrefix line, parser
+        return match
+    return false
 
-  # Finds the minimum index out of two indexes, taking into account indexes of -1
-  minIndex: (a, b) ->
-    return a if a is b
-    return a if b < 0
-    return b if a < 0
-    return a if a < b
-    return b if b < a
+  matchPrefix: (text, parser) ->
+    if typeof parser.trigger is 'function' then parser.trigger(text) else text.match(parser.trigger)?[0]
 
-  # Checks if one string ends in another
-  stringEndsWith: (a, b) ->
-    a.substr(a.length - b.length, a.length) == b
-
-  stringStartsWith: (a, b) ->
-    a.substr(0, b.length) == b
+  getParser: (name, parsers) ->
+    for index, parser of parsers
+      if parser.name is name
+        return parser
+    null

--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -1,0 +1,150 @@
+##
+# file: parsers.coffee
+# author: @marcotheporo
+#
+# Parser schema
+# name: <string> The name of the parser
+# trigger: <RegExp|func (string) -> <bool>> A RegExp that when tested
+#   using string.match(trigger), or a function that when tested using
+#   trigger(string) will return a boolean based on whether the string may trigger
+#   an autocompletion. (this should test for the beginning portion of a closing
+#   tag only).
+# test: <RegExp> determines whether the given string is a candidate
+#   for a full parse, (opening or closing)
+# parse: <func (string) -> <TagDescriptor|null>> A function that parses a tag from
+#   the front of the given text or rejects by returning null
+# getPair: <func (TagDescriptor) -> <string>> renders a closing tag to match
+#   that given by the TagDescriptor
+#
+# TagDescriptor Schema
+# opening: <bool>
+# closing: <bool>
+# selfClosing: <bool>
+# element: <string> Whilst required, this property doesn't apply to all types
+#   of tags, for example there is only one variety of html comment. If you don't
+#   have any unique data to put in here, use the tag type
+# type: <string> it's best to just put the parser name in here
+# length: <number>
+#
+
+module.exports =
+  xmlparser:
+    name: "xml"
+    trigger: /<\/$/
+    test: /^</
+    parse: (text) ->
+      result = {
+        opening: false
+        closing: false
+        selfClosing: false
+        element: ''
+        type: @name
+        length: 0
+      }
+      match = text.match(/^<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+      if match
+        result.element     = match[2]
+        result.length      = match[0].length
+        if @emptyTags.indexOf(result.element.toLowerCase()) > -1
+          result.selfClosing = true
+        else
+          result.opening     = if match[1] or match[7] then false else true
+          result.closing     = if match[1] then true else false
+          result.selfClosing = if match[7] then true else false
+        result
+      else
+        null
+    getPair: (tagDescriptor) ->
+      "</#{tagDescriptor.element}>"
+    emptyTags: []
+  xmlcdataparser:
+    name: 'xml-cdata'
+    trigger: /\]\]$/
+    test: /^(<!\[|]]>)/
+    parse: (text) ->
+      result = {
+        opening: false
+        closing: false
+        selfClosing: false
+        element: 'xml-cdata'
+        type: @name
+        length: 0
+      }
+      match = text.match(/(<!\[CDATA\[)|(\]\]>)/i)
+      if match
+        result.length  = match[0].length
+        result.opening = if match[1] then true else false
+        result.closing = if match[2] then true else false
+        result
+      else
+        null
+    getPair: () ->
+      return "]]>"
+  # DISABLED
+  xmlcommentparser:
+    name: 'xml-comment'
+    # FIXME tries to close the comment immediately after you open it
+    # eg. Input: `<!--` Result: `<!-->`
+    # DISABLED FOR NOW
+    trigger: /(--)$/
+    test: /^(<!--|-->)/
+    parse: (text) ->
+      result = {
+        opening: false
+        closing: false
+        selfClosing: false
+        element: 'xml-comment'
+        type: @name
+        length: 0
+      }
+      match = text.match(/(<!--|-->)/)
+      if match
+        result.length  = match[0].length
+        result.opening = if match[1] then true else false
+        result.closing = if match[2] then true else false
+        result
+      else
+        null
+    getPair: () ->
+      return "-->"
+  underscoretemplateparser:
+    name: 'underscore-template',
+    trigger: null
+    test: /<%=.+?%>/
+    parse: (text) ->
+      {
+        type: @name,
+        selfClosing: true,
+        length: text.match(@test)[0].length
+      }
+    getPair: null
+  # DISABLED
+  mustacheparser:
+    name: 'mustache',
+    trigger: /\{\{\/$/
+    test: /^{{[\^\/#]/
+    parse: (text) ->
+      result = {
+        opening: false
+        closing: false
+        selfClosing: false
+        element: ''
+        type: @name
+        length: 0
+      }
+      match = text.match(/\{\{([#\/])([^\s]+?)(\s+?([^\s]+?))?(\s)*?\}\}/i)
+      if match
+        console.log match
+        result.opening = if match[1] is '#' then true else false
+        result.closing = not result.opening
+        result.element = match[2]
+        result.length = match[0].length
+        return result
+      else
+        return null
+    getPair: (tagDescriptor) ->
+      # FIXME HACK If you type `{{`, the editor will autmagically insert the
+      #   matching `}}`. If we include the `}}` in the rendered tag then after
+      #   completing you get `{{/blah}}}}`. Autocomplete plus is smart enough
+      #   to mitigate this so I'm not sure which approach to use.
+      "{{/#{tagDescriptor.element}}}"

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -1,468 +1,66 @@
 ##
-# file: less-than-slash-spec.coffee
-# author: @mrhanlon
+# file: provider-spec.coffee
+# author: @MarcoThePoro
 #
-LessThanSlash = require '../lib/less-than-slash'
+
+{ reduceTags, traverse, getParser } = require '../lib/less-than-slash.coffee'
+{ xmlparser } = require '../lib/parsers.coffee'
 
 describe "LessThanSlash", ->
-  activationPromise = null
-  workspaceElement = null
+  parsers = [xmlparser]
+  xmlparser.emptyTags = [
+    "!doctype",
+    "br",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "area",
+    "base",
+    "col",
+    "command",
+    "embed",
+    "keygen",
+    "param",
+    "source",
+    "track",
+    "wbr"
+  ]
 
-  beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
-    activationPromise = atom.packages.activatePackage('less-than-slash')
+  describe "getParser", ->
+    it 'returns the parser based on the type', ->
+      parser = {name: 'a'}
+      expect(getParser('a', [parser])).toEqual(parser)
 
-  describe "onSlash", ->
-    it "returns the appropriate closing tag", ->
-      getCheckText = ->
-        '<div class="moo"><a href="/cows">More cows!</'
-      getText = ->
-        '<div class="moo"><a href="/cows">More cows!<'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</a>'
+  describe "traverse", ->
+    it "converts a string into a list of tag descriptors", ->
+      expect(traverse('<a></a>', parsers)).toEqual([
+        getParser('xml', parsers).parse('<a>'),
+        getParser('xml', parsers).parse('</a>')
+      ])
+      expect(traverse('<a></a>', parsers)).toEqual([
+        getParser('xml', parsers).parse('<a>'),
+        getParser('xml', parsers).parse('</a>')
+      ])
 
-      getCheckText = ->
-        '<div class="moo"><a href="/cows">More cows!</a></'
-      getText = ->
-        '<div class="moo"><a href="/cows">More cows!</a><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</div>'
-
-    it "also works for comments", ->
-      getCheckText = ->
-        '<!--<div class="moo"><a href="/cows">More cows!</a></div></'
-      getText = ->
-        '<!--<div class="moo"><a href="/cows">More cows!</a></div><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '-->'
-
-      getCheckText = ->
-        '<div class="moo"><a href="/cows"><!--More cows!--></'
-      getText = ->
-        '<div class="moo"><a href="/cows"><!--More cows!--><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</a>'
-
-    it "also works inside comments", ->
-      getCheckText = ->
-        '<!--<div class="moo"><a href="/cows">More cows!</a></'
-      getText = ->
-        '<!--<div class="moo"><a href="/cows">More cows!</a><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</div>'
-
-    it "also works for XML CDATA", ->
-      getCheckText = ->
-        '<![CDATA[<div class="moo"><a href="/cows">More cows!</a></div></'
-      getText = ->
-        '<![CDATA[<div class="moo"><a href="/cows">More cows!</a></div><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe ']]>'
-
-      getCheckText = ->
-        '<div class="moo"><a href="/cows"><![CDATA[More cows!]]></'
-      getText = ->
-        '<div class="moo"><a href="/cows"><![CDATA[More cows!]]><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</a>'
-
-    it "also works inside XML CDATA", ->
-      getCheckText = ->
-        '<![CDATA[<div class="moo"><a href="/cows">More cows!</a></'
-      getText = ->
-        '<![CDATA[<div class="moo"><a href="/cows">More cows!</a><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</div>'
-
-    it "returns null if there are no tags to close", ->
-      getCheckText = ->
-        '<div class="moo"><a href="/cows">More cows!</a></div></'
-      getText = ->
-        '<div class="moo"><a href="/cows">More cows!</a></div><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe null
-
-      getCheckText = ->
-        '</'
-      getText = ->
-        '<'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe null
-
-    it "works around mismatched tags", ->
-      getCheckText = ->
-        '<div class="moo"><a href="/cows">More cows!</i></'
-      getText = ->
-        '<div class="moo"><a href="/cows">More cows!</i><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</a>'
-
-      getCheckText = ->
-        '<div class="moo"><a href="/cows"><em>More cows!</i></a></'
-      getText = ->
-        '<div class="moo"><a href="/cows"><em>More cows!</i></a><'
-      expect(LessThanSlash.onSlash(getCheckText, getText)).toBe '</div>'
-
-  describe "getNextCloseableTag", ->
-    it "returns the next closeable tag", ->
-      text = "<div>"
-      expect(LessThanSlash.getNextCloseableTag(text)).toEqual {
-        element: "div",
-        type: "xml"
-      }
-
-      text = "<div><a><br></a><ul><li></li><li></li></ul>"
-      expect(LessThanSlash.getNextCloseableTag(text)).toEqual {
-        element: "div",
-        type: "xml"
-      }
-
-    it "returns null when all tags are closed", ->
-      text = "<div><a></a></div>"
-      expect(LessThanSlash.getNextCloseableTag(text)).toBe null
-
-  describe "findUnclosedTags", ->
-    it "returns a list of unclosed tags", ->
-      text = "<div><a></a><em>"
-      expect(LessThanSlash.findUnclosedTags(text)).toEqual [
-        {
-          element: "div",
-          type: "xml"
-        }
-        {
-          element: "em",
-          type: "xml"
-        }
-      ]
-
-      text = "<div><a></a></div>"
-      expect(LessThanSlash.findUnclosedTags(text)).toEqual []
-
-    it "still works around mismatched tags", ->
-      text = "<div></i><a>"
-      expect(LessThanSlash.findUnclosedTags(text)).toEqual [
-        {
-          element: "div",
-          type: "xml"
-        }
-        {
-          element: "a",
-          type: "xml"
-        }
-      ]
-
-  describe "handleNextTag", ->
-    it "consumes the next tag and places it in the stack", ->
-      text = "<div><a>"
-      unclosedTags = []
-      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "<a>"
-      expect(unclosedTags).toEqual [
-        {
-          element: "div",
-          type: "xml"
-        }
-      ]
-
-    it "consumes the next closing tag and removes it from the stack", ->
-      text = "</a></div>"
-      unclosedTags = [
-        {
-          element: "div",
-          type: "xml"
-        }
-        {
-          element: "a",
-          type: "xml"
-        }
-      ]
-      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "</div>"
-      expect(unclosedTags).toEqual [
-        {
-          element: "div",
-          type: "xml"
-        }
-      ]
-
-    it "discards mismatched tags", ->
-      text = "</em></a></div>"
-      unclosedTags = [
-        {
-          element: "div",
-          type: "xml"
-        }
-        {
-          element: "a",
-          type: "xml"
-        }
-      ]
-      expect(LessThanSlash.handleNextTag(text, unclosedTags)).toBe "</a></div>"
-      expect(unclosedTags).toEqual [
-        {
-          element: "div",
-          type: "xml"
-        }
-        {
-          element: "a",
-          type: "xml"
-        }
-      ]
-
-  describe "parseNextTag", ->
-    it "parses tags, comments, and cdata", ->
-      text = "<div>"
-      expect(LessThanSlash.parseNextTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div',
-        type: 'xml'
-        length: 5
-      }
-
-      text = "<!--"
-      expect(LessThanSlash.parseNextTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: '-->'
-        type: 'xml-comment'
-        length: 4
-      }
-
-      text = "<![CDATA["
-      expect(LessThanSlash.parseNextTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: ']]>'
-        type: 'xml-cdata'
-        length: 9
-      }
-
-  describe "parseXMLTag", ->
-    it "parses an opening tag", ->
-      text = "<div>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div',
-        type: 'xml'
-        length: 5
-      }
-
-    it "parses a closing tag", ->
-      text = "</div>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: false
-        closing: true
-        selfClosing: false
-        element: 'div'
-        type: 'xml'
-        length: 6
-      }
-
-    it "parses self closing tags", ->
-      text = "<br/>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: false
-        closing: false
-        selfClosing: true
-        element: 'br'
-        type: 'xml'
-        length: 5
-      }
-
-    it "returns null when there is no tag", ->
-      text = "No tag here!"
-      expect(LessThanSlash.parseXMLTag text).toBe null
-
-    it "works around element properties", ->
-      text = "<div class=\"container\">"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div'
-        type: 'xml'
-        length: 23
-      }
-
-    it "doesn't care which quotes you use", ->
-      text = "<div class='container'>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div'
-        type: 'xml'
-        length: 23
-      }
-
-      text = "<div class=`container`>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div'
-        type: 'xml'
-        length: 23
-      }
-
-    it "plays nicely with JSX curly brace property values", ->
-      text = "<input type=\"text\" disabled={this.props.isDisabled}/>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: false
-        closing: false
-        selfClosing: true
-        element: 'input'
-        type: 'xml'
-        length: 53
-      }
-
-    it "plays nicely with multiline namespaced attributes", ->
-      text = "<elem\n ns1:attr1=\"text\"\n  ns2:attr2=\"text\"\n>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'elem'
-        type: 'xml'
-        length: 44
-      }
-
-    it "works around weird spacing", ->
-      text = "<div  class=\"container\" \n  foo=\"bar\">"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'div'
-        type: 'xml'
-        length: 37
-      }
-
-    it "works around lone properties", ->
-      text = "<input type=\"text\" required/>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: false
-        closing: false
-        selfClosing: true
-        element: 'input'
-        type: 'xml'
-        length: 29
-      }
-
-    it "doesn't have a cow when properties contain a '>'", ->
-      text = "<p ng-show=\"3 > 5\">Uh oh!"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'p'
-        type: 'xml'
-        length: 19
-      }
-
-    it "finds the expected tag when tags are nested", ->
-      text = "<a><i>"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'a'
-        type: 'xml'
-        length: 3
-      }
-
-    it "finds the expected tag when tags with attributes are nested", ->
-      text = "<a href=\"#\"><i class=\"fa fa-home\">"
-      expect(LessThanSlash.parseXMLTag text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: 'a'
-        type: 'xml'
-        length: 12
-      }
-
-  describe "parseXMLComment", ->
-    it "parses comments as if they were tags", ->
-      text = "<!--"
-      expect(LessThanSlash.parseXMLComment text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: '-->'
-        type: 'xml-comment'
-        length: 4
-      }
-
-      text = "-->"
-      expect(LessThanSlash.parseXMLComment text).toEqual {
-        opening: false
-        closing: true
-        selfClosing: false
-        element: '-->'
-        type: 'xml-comment'
-        length: 3
-      }
-
-  describe "parseXMLCDATA", ->
-    it "parses CDATA as if they were tags", ->
-      text = "<![CDATA["
-      expect(LessThanSlash.parseXMLCDATA text).toEqual {
-        opening: true
-        closing: false
-        selfClosing: false
-        element: ']]>'
-        type: 'xml-cdata'
-        length: 9
-      }
-
-      text = "]]>"
-      expect(LessThanSlash.parseXMLCDATA text).toEqual {
-        opening: false
-        closing: true
-        selfClosing: false
-        element: ']]>'
-        type: 'xml-cdata'
-        length: 3
-      }
-
-  describe "isEmpty", ->
-    it "is true when it isEmpty", ->
-      expect(LessThanSlash.isEmpty "br").toBe true
-
-    it "is false when not isEmpty", ->
-      expect(LessThanSlash.isEmpty "div").toBe false
-
-  describe "minIndex", ->
-    it "returns the lower number", ->
-      lower = LessThanSlash.minIndex(3, 5)
-      expect(lower).toBe 3
-
-      lower = LessThanSlash.minIndex(5, 3)
-      expect(lower).toBe 3
-
-    it "discards a negative index", ->
-      lower = LessThanSlash.minIndex(3, -1)
-      expect(lower).toBe 3
-
-      lower = LessThanSlash.minIndex(-1, 3)
-      expect(lower).toBe 3
-
-    it "passes on double negative indicies", ->
-      lower = LessThanSlash.minIndex(-1, -1)
-      expect(lower).toBe -1
-
-  describe "stringEndsWith", ->
-    it "returns true if the first string ends in the second", ->
-      a = "don't have a cow, man!"
-      b = "man!"
-      expect(LessThanSlash.stringEndsWith(a, b)).toBe true
-
-    it "returns false if the first string does not end in the second", ->
-      a = "chunky bacon"
-      b = "chunky"
-      expect(LessThanSlash.stringEndsWith(a, b)).toBe false
-
-  describe "stringStartsWith", ->
-    it "returns true if the first string ends starts with the second", ->
-      a = "chunky bacon"
-      b = "chunky"
-      expect(LessThanSlash.stringStartsWith(a, b)).toBe true
-
-    it "returns false if the first string does not start with the second", ->
-      a = "don't have a cow, man!"
-      b = "man!"
-      expect(LessThanSlash.stringStartsWith(a, b)).toBe false
+  describe "reduceTags", ->
+    it "matches tags, leaving only those that are unclosed", ->
+      expect(reduceTags(traverse('<a>', parsers))).toEqual([
+        getParser('xml', parsers).parse('<a>')
+      ])
+      expect(reduceTags(traverse('<a></a>', parsers))).toEqual([])
+      expect(reduceTags(traverse('<a><div></a>', parsers))).toEqual([])
+      expect(reduceTags(traverse('<a><div></div></a>', parsers))).toEqual([])
+      expect(reduceTags(traverse('<a><div><div></div></div></a>', parsers))).toEqual([])
+      expect(reduceTags(traverse('<a><div><div>', parsers))).toEqual([
+        getParser('xml', parsers).parse('<a>')
+        getParser('xml', parsers).parse('<div>')
+        getParser('xml', parsers).parse('<div>')
+      ])
+      expect(reduceTags(traverse('<a><div><i></div>', parsers))).toEqual([
+        getParser('xml', parsers).parse('<a>')
+      ])
+      expect(reduceTags(traverse('<a></a><div>', parsers))).toEqual([
+        getParser('xml', parsers).parse('<div>')
+      ])


### PR DESCRIPTION
Enhancement #7 **Integrate with autocomplete-plus package**

What's new
---
Two modes: 'Immeditate' and 'Suggest'
Immediate is the 'classic' less-than-slash, completing closing tags as soon as you type them.
Suggest is the newer, autocomplete-plus provider. When you begin to close a tag, the rest of it will show up in an autocomplete suggestion box next to your cursor which you can then accept or ignore.

Under the hood
---
Parsers are now contained in a separate file and are now more modular and pluggable so they can be tested independently of less-than-slash functionality and can be injected into less-than-slash, bringing us closer to #21 **user defined parsers**.

The tag traversal logic has been vastly simplified, now contained in the two functions `traverse` (maybe this should be named something different like `parseText`) and `reduceTags`.
`traverse` takes input text and returns a list of tag descriptors.
`reduceTags` looks through a list of tag descriptors and eliminates those that make valid pairs, resulting in a list of tags that are yet to be closed.

`getPrefix` is now responsible for testing whether to trigger an autocompletion or not, and is completely dynamic with respect to what parsers are active.

`checkPrefix` verifies that the prefix used to trigger a completion actually matches the next available completion so that you can't write `<![CDATA[ </` and recieve `<![CDATA[ ]]>` (although I'm still debating whether it should be a feature of less-than-slash that `</` can complete any supported tag. Thoughts on this issue?

Immediate mode is run by the `forceCompleter` which listens directly to the texteditor and manipulates it when a trigger has been detected. (I'm not sure this should be called a force completer but I can't call it 'autocomplete' anymore since there's now an autocomplete-plus mode...)
Suggest mode activates the autcomplete-plus `provider`, passing on completions to autocomplete-plus.

Issues/Todo
---
- [ ] Finish unit tests
- [ ] Fix the `xmlcomment` plugin
- [ ] Fix the `mustache` plugin
- [ ] Ensure consistent style across all source (coffeelint.json?)
- [ ] More documentation, proper notation for the parser API
- [ ] Decide whether `</` should complete any type of tag
- [ ] Remove all `console.log`s
- [ ] Consider renaming `traverse`, `forceCompleter`, `getPrefix`, `checkPrefix`

---
Also should fix #23 since I added a `deactivate` hook to the package.