### PR TITLE
Fix package not working on existing buffers after being disabled and reenabled

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -13,7 +13,9 @@ module.exports =
       default: "!doctype, br, hr, img, input, link, meta, area, base, col, command, embed, keygen, param, source, track, wbr"
 
   deactivate: (state) ->
-    @disposable[key].dispose() for key in Object.keys @disposable
+    for key in Object.keys @disposable
+      @disposable[key].dispose()
+      delete @disposable[key]
 
   activate: (state) ->
     # Register config change handler to update the empty tags list


### PR DESCRIPTION
Since the key for a disposable is its buffer id, if you were to disable the package and re-enable it, disposables would be disposed of, but their remains would stay in @disposable and prevent new listeners from being attached to existing buffers.