### PR TITLE
Support double LT

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -165,7 +165,7 @@ module.exports =
       type: 'xml'
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+    match = text.match(/<(\/)?([^\s\/<>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length


### PR DESCRIPTION
support `<<x></x>` (is used by https://github.com/stijnsanders/xxm as an escape-to-html code)