### PR TITLE
fixes #32 Prevent xmlparser from capturing leading tag openings `<`

### DIFF
--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -165,7 +165,7 @@ module.exports =
       type: 'xml'
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+    match = text.match(/<(\/)?([^\s\/<>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length

--- a/lib/less-than-slash.coffee
+++ b/lib/less-than-slash.coffee
@@ -165,7 +165,7 @@ module.exports =
       type: 'xml'
       length: 0
     }
-    match = text.match(/<(\/)?([^\s\/<>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+    match = text.match(/^<(\/)?([^\s\/<>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
     if match
       result.element     = match[2]
       result.length      = match[0].length

--- a/spec/less-than-slash-spec.coffee
+++ b/spec/less-than-slash-spec.coffee
@@ -375,6 +375,10 @@ describe "LessThanSlash", ->
         length: 12
       }
 
+    it "does not consume leading tag openings (<)", ->
+      text = "<<a>"
+      expect(LessThanSlash.parseXMLTag text).toBe null
+
   describe "parseXMLComment", ->
     it "parses comments as if they were tags", ->
       text = "<!--"


### PR DESCRIPTION
Prevents silly things from happening when you use a lot of `<`s.
eg. `<<<hi></` -> `<<<hi></<<hi>`

Thanks to @stijnsanders for picking up on this.

Closes https://github.com/mrhanlon/less-than-slash/pull/32