### PR TITLE
stop xmlparser from parsing comments as tags; fixes #39

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -39,7 +39,7 @@ module.exports =
         type: @name
         length: 0
       }
-      match = text.match(/^<(\/)?([^\s\/<>]+)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
       if match
         result.element     = match[2]
         result.length      = match[0].length

--- a/spec/parsers-spec.coffee
+++ b/spec/parsers-spec.coffee
@@ -149,6 +149,10 @@ describe "xmlparser", ->
       text = "<!--<div>"
       expect(xmlparser.parse(text)).toEqual null
 
+    it "does not capture comments", ->
+      text = "<!-- COMMENT -->>"
+      expect(xmlparser.parse(text)).toEqual null
+
   describe "getPair", ->
     it "returns the appropriate closing tag", ->
       expect(xmlparser.getPair(xmlparser.parse('<div>'))).toBe('</div>')


### PR DESCRIPTION
Closed comments were being parsed like normal tags. The parsing rejects now rejects any tags that have a leading `!`. Hopefully this doesn't conflict with anything, the only tags affected as far as I know are `!doctype` which doesn't need completing, and `<![CDATA[ ]]>` which we've accounted for in another parser.

Fixes https://github.com/mrhanlon/less-than-slash/issues/39