### PR TITLE
allow newlines within property values

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -39,7 +39,7 @@ module.exports =
         type: @name
         length: 0
       }
-      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{](.*?)["'`}])?)*\s*(\/)?>/i)
+      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
       if match
         result.element     = match[2]
         result.length      = match[0].length

--- a/spec/parsers-spec.coffee
+++ b/spec/parsers-spec.coffee
@@ -97,6 +97,17 @@ describe "xmlparser", ->
         length: 37
       }
 
+    it "works when property values are spread across multiple lines", ->
+      text = "<div\n  style={\n    fontFamily: \"Comic Sans MS\",\n  }\n>"
+      expect(xmlparser.parse(text)).toEqual {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        type: 'xml'
+        length: 53
+      }
+
     it "works around lone properties", ->
       text = "<input type=\"text\" required/>"
       expect(xmlparser.parse(text)).toEqual {


### PR DESCRIPTION
I noticed less than slash wasn't closing some of my JSX, for example if I type
```javascript
<div
  style={{
    height: '100%',
    display: 'flex',
    justifyContent: 'space-around',
    alignItems: 'center',
  }}
>
  Blah
</
```
It won't complete the tag.

The xml parser should now match any character within a property value.