### PR TITLE
Support JSX spread property syntax

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -29,7 +29,7 @@ module.exports =
   xmlparser:
     name: "xml"
     trigger: /<\/$/
-    test: /^</
+    test: /^<.*?>/
     parse: (text) ->
       result = {
         opening: false

--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -39,9 +39,8 @@ module.exports =
         type: @name
         length: 0
       }
+      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:\[\]\(\)\*\@\#]+|\{\.\.\..*?\})(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
 
-      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:\[\]\(\)\*\@\#]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
-      # match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
       if match
         result.element     = match[2]
         result.length      = match[0].length

--- a/spec/parsers-spec.coffee
+++ b/spec/parsers-spec.coffee
@@ -141,6 +141,17 @@ describe "xmlparser", ->
         length: 53
       }
 
+    it "works with JSX spread properties", ->
+      text = "<MyComponent {...props} {...{ style: { fontFamily: 'Comic Sans MS' } }}>"
+      expect(xmlparser.parse(text)).toEqual {
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'MyComponent'
+        type: 'xml'
+        length: 72
+      }
+
     it "works around lone properties", ->
       text = "<input type=\"text\" required/>"
       expect(xmlparser.parse(text)).toEqual {


### PR DESCRIPTION
In jsx you can use the spread property syntax `{...object}` in place of a property-value pair in a tag. less-than-slash was skipping any tags that had this.

This adds support in the xml parser.

I'm getting concerned that maybe our regex is getting too complicated, but I don't know if it's actually causing any performance issues so it should be okay for now (Maybe JSX should get its own parser? Add a JSX option to the settings?). I changed the xmlparser test so that it checks that there is a (potential) whole tag before executing the more complex regex in the parse function. Not sure how much benefit this is.

@mrhanlon review?