### PR TITLE
updated test and parser for [stuff] tags

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -39,7 +39,9 @@ module.exports =
         type: @name
         length: 0
       }
-      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
+
+      match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:\[\]\(\)\*\@\#]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
+      # match = text.match(/^<(\/)?([^\s\/<>!][^\s\/<>]*)(\s+([\w-:]+)(=["'`{]([\S\s]*?)["'`}])?)*\s*(\/)?>/i)
       if match
         result.element     = match[2]
         result.length      = match[0].length

--- a/spec/parsers-spec.coffee
+++ b/spec/parsers-spec.coffee
@@ -97,6 +97,42 @@ describe "xmlparser", ->
         length: 37
       }
 
+    it "handles angular-style brackets", ->
+      text = "<div [ngClass]=\"{'foo': true}\">"
+      expect(xmlparser.parse(text)).toEqual {
+        opening: true
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        type: 'xml'
+        length: 31
+      }
+
+    it "handles angular-style parentheses", ->
+      text = "<div (ngClass)=\"{'foo': true}\">"
+      expect(xmlparser.parse(text)).toEqual {
+        opening: true
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        type: 'xml'
+        length: 31
+      }
+
+    it "handles angular-style special characters", ->
+      text = "<div @\#*ngClass=\"{'foo': true}\">"
+      expect(xmlparser.parse(text)).toEqual {
+        opening: true
+        opening: true
+        closing: false
+        selfClosing: false
+        element: 'div'
+        type: 'xml'
+        length: 32
+      }
+
     it "works when property values are spread across multiple lines", ->
       text = "<div\n  style={\n    fontFamily: \"Comic Sans MS\",\n  }\n>"
       expect(xmlparser.parse(text)).toEqual {


### PR DESCRIPTION
Angular 2+ html elements can contain [square] (parentheses) and some special characters (*, @, and # at least).

This updates the test on xmlparser to reflect that and proposes an update to the matcher regex that supports that. 