### PR TITLE
Make default self closing tags case sensitive

### DIFF
--- a/lib/parsers.coffee
+++ b/lib/parsers.coffee
@@ -45,7 +45,7 @@ module.exports =
       if match
         result.element     = match[2]
         result.length      = match[0].length
-        if @emptyTags.indexOf(result.element.toLowerCase()) > -1
+        if @emptyTags.indexOf(result.element) > -1
           result.selfClosing = true
         else
           result.opening     = if match[1] or match[7] then false else true


### PR DESCRIPTION
Many modern web frameworks disambiguate their own custom tags from native html tags by capitalising the name of the tag. For example, I am using React and [Next.js](https://github.com/zeit/next.js), which exposes a `Link` component. When I try to autocomplete a `Link` tag, it is registered by less-than-slash as a self closing `link` tag and ignored, usually giving me an incorrect completion.

Making tag matching case sensitive will fix this issue.