### PR TITLE
Deprecate less-than-slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
+### v0.17.0
+
+Deprecated the package.
+
 ### v0.16.0
 
 The apm publisher bugged out an skipped v0.15.0.
 
 Enhancements:
 
-- Added 'return cursor' setting. When enabled, the cursor will be placed 
+- Added 'return cursor' setting. When enabled, the cursor will be placed
   just closed tag. This allows to you write both the opening and closing
-  tag first, then return the cursor to insert between the just-typed 
+  tag first, then return the cursor to insert between the just-typed
   tags; #37.
 
-Bug fixes: 
+Bug fixes:
 
 - XML Parser closes comment tags; #39.
 
@@ -19,7 +23,7 @@ Enhancements:
 
 - Autocomplete plus integration #24
 
-Bug fixes: 
+Bug fixes:
 
 - Editor crashes when <br> closed #36
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # </ Less Than-Slash
 
+** :warning: This package is deprecated. :warning: **
+
+
 [![Build Status](https://travis-ci.org/mrhanlon/less-than-slash.png)](https://travis-ci.org/mrhanlon/less-than-slash)
 
 Atom.io package for closing open tags when less-than, slash (`</`) is typed, like in Sublime Text 3.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+function activate() {
+  atom.notifications.addWarning("less-than-slash package is deprecated");
+  atom.packages.disablePackage("less-than-slash");
+}
+exports.activate = activate;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-than-slash",
-  "main": "./lib/less-than-slash",
+  "main": "./index.js",
   "version": "0.19.0",
   "description": "Adds automatic closing of HTML tags when less-than, slash (</) is typed.",
   "author": {


### PR DESCRIPTION
This package destroys Atom performance when you type. It takes seconds for each keypress until it is able to process the inputs. It almost makes the editor unusable

Atom achieves this high performance by using native code.
- Atom's text engine is written in C++: https://github.com/atom/superstring
- Atom's syntax highlighter is written in Rust: https://github.com/tree-sitter/tree-sitter

Unless you can provide the same performance, you should not add a feature that makes Atom unusable. Being the owner of @atom-community, I have heard many gripes about the performance of typing until I found that the issue was this package.


I have attached the CPU profile:
[CPU-20210207T150604.zip](https://github.com/mrhanlon/less-than-slash/files/5940003/CPU-20210207T150604.zip)

![image](https://user-images.githubusercontent.com/16418197/107163566-c60d9f80-696f-11eb-91fd-892b006827c3.png)

